### PR TITLE
fix: removes passwords fields from the responses

### DIFF
--- a/backend/src/main/java/com/tcs/dhv/domain/dto/UserProfileDto.java
+++ b/backend/src/main/java/com/tcs/dhv/domain/dto/UserProfileDto.java
@@ -1,5 +1,6 @@
 package com.tcs.dhv.domain.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tcs.dhv.domain.entity.User;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
@@ -29,8 +30,10 @@ public record UserProfileDto(
     LocalDateTime createdAt,
     LocalDateTime updatedAt,
 
+    @JsonIgnore
     String currentPassword,
 
+    @JsonIgnore
     @Size(min = 8, max = 128,
         message = "New password must be between 8 and 128 characters")
     @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@#$%^&+=!?.,;:~`<>{}\\[\\]()_-]).{8,128}$",


### PR DESCRIPTION
Prevents currentPassword and newPassword fields from being serialized in JSON responses, by this they will not appear in responses (even though they were always null)