### PR TITLE
fix(auth): renamed emailVerification field, allow duplicate names

### DIFF
--- a/backend/src/main/java/com/tcs/dhv/domain/dto/RegisterResponse.java
+++ b/backend/src/main/java/com/tcs/dhv/domain/dto/RegisterResponse.java
@@ -3,6 +3,6 @@ package com.tcs.dhv.domain.dto;
 public record RegisterResponse(
     String name,
     String email,
-    boolean emailVerificationRequired
+    boolean emailVerified
 ) {
 }

--- a/backend/src/main/java/com/tcs/dhv/domain/entity/User.java
+++ b/backend/src/main/java/com/tcs/dhv/domain/entity/User.java
@@ -42,11 +42,10 @@ public class User {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @NotNull
+    @Column(nullable = false)
     private String name;
 
-    @NotNull
-    @Column(unique = true)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @NotNull

--- a/backend/src/main/java/com/tcs/dhv/service/AuthService.java
+++ b/backend/src/main/java/com/tcs/dhv/service/AuthService.java
@@ -66,10 +66,8 @@ public class AuthService {
 
     @Transactional
     public User registerUser(RegisterRequest registerRequest) {
-        if (userRepository.existsByName(registerRequest.name()) ||
-            userRepository.existsByEmail(registerRequest.email())
-        ) {
-            throw new ValidationException("Username or Email already exists");
+        if (userRepository.existsByEmail(registerRequest.email())) {
+            throw new ValidationException("Email already exists");
         }
 
         final var user = User.builder()

--- a/backend/src/main/java/com/tcs/dhv/service/EmailService.java
+++ b/backend/src/main/java/com/tcs/dhv/service/EmailService.java
@@ -74,8 +74,8 @@ public class EmailService {
     ) {
         final var token = otpService.generateAndStoreOtp(userId);
 
-        final var emailVerificationUrl = "%s/api/auth/email/verify?uid=%s&t=%s"
-            .formatted(appBaseUrl, userId, token);
+        final var emailVerificationUrl = "%s/verified/%s/%s"
+            .formatted(clientUrl, userId, token);
 
         final var context = new Context();
         context.setVariable("verifyLink", emailVerificationUrl);


### PR DESCRIPTION
- Updated the verification link sent in the email to point to the frontend route `/verified/:uid/:token` instead of the backend API. The frontend will now handle the request and call the backend internally
- Renamed the `emailVerificationRequired` field in `RegisterResponse` to `emailVerified` for clarity and consistency with its actual purpose
- Also added a check to prevent users from registering with duplicate email addresses, allowing multiple users to have the same name but ensuring email uniqueness