### PR TITLE
feat(auth): implemented forgot password and reset password flow

### DIFF
--- a/backend/src/main/java/com/tcs/dhv/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tcs/dhv/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
 
     public static final String[] PUBLIC_ENDPOINTS = {
         "/api/auth/**",
-        "/api/tracking/**"
+        "/api/tracking/**",
+        "/api/auth/password/**"
     };
 
     @Value("${dhv.client-url}")

--- a/backend/src/main/java/com/tcs/dhv/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tcs/dhv/config/SecurityConfig.java
@@ -33,8 +33,7 @@ public class SecurityConfig {
 
     public static final String[] PUBLIC_ENDPOINTS = {
         "/api/auth/**",
-        "/api/tracking/**",
-        "/api/auth/password/**"
+        "/api/tracking/**"
     };
 
     @Value("${dhv.client-url}")

--- a/backend/src/main/java/com/tcs/dhv/controller/PasswordResetController.java
+++ b/backend/src/main/java/com/tcs/dhv/controller/PasswordResetController.java
@@ -1,0 +1,25 @@
+package com.tcs.dhv.controller;
+
+import com.tcs.dhv.domain.dto.ForgotPasswordDto;
+import com.tcs.dhv.service.PasswordResetService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/password")
+@RestController
+public class PasswordResetController {
+
+    private final PasswordResetService passwordResetService;
+
+    @PostMapping("/reset-link")
+    public ResponseEntity<String> requestPasswordReset(@Valid @RequestBody ForgotPasswordDto forgotPassword) {
+        passwordResetService.sendResetToken(forgotPassword.email());
+        return ResponseEntity.ok("If email is registered a reset link will be sent!");
+    }
+}

--- a/backend/src/main/java/com/tcs/dhv/controller/PasswordResetController.java
+++ b/backend/src/main/java/com/tcs/dhv/controller/PasswordResetController.java
@@ -1,6 +1,7 @@
 package com.tcs.dhv.controller;
 
 import com.tcs.dhv.domain.dto.ForgotPasswordDto;
+import com.tcs.dhv.domain.dto.ResetPasswordDto;
 import com.tcs.dhv.service.PasswordResetService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,9 +18,19 @@ public class PasswordResetController {
 
     private final PasswordResetService passwordResetService;
 
-    @PostMapping("/reset-link")
-    public ResponseEntity<String> requestPasswordReset(@Valid @RequestBody ForgotPasswordDto forgotPassword) {
+    @PostMapping("/forgot")
+    public ResponseEntity<String> requestPasswordReset(
+        @Valid @RequestBody ForgotPasswordDto forgotPassword
+    ) {
         passwordResetService.sendResetToken(forgotPassword.email());
         return ResponseEntity.ok("If email is registered a reset link will be sent!");
+    }
+
+    @PostMapping("/reset")
+    public ResponseEntity<String> resetPassword(
+        @Valid @RequestBody ResetPasswordDto resetPassword
+    ) {
+        passwordResetService.resetPassword(resetPassword.token(), resetPassword.newPassword());
+        return ResponseEntity.ok("Password has been reset successfully");
     }
 }

--- a/backend/src/main/java/com/tcs/dhv/controller/PasswordResetController.java
+++ b/backend/src/main/java/com/tcs/dhv/controller/PasswordResetController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,9 +29,10 @@ public class PasswordResetController {
 
     @PostMapping("/reset")
     public ResponseEntity<String> resetPassword(
+        @RequestHeader("Authorization") String token,
         @Valid @RequestBody ResetPasswordDto resetPassword
     ) {
-        passwordResetService.resetPassword(resetPassword.token(), resetPassword.newPassword());
+        passwordResetService.resetPassword(token, resetPassword.newPassword());
         return ResponseEntity.ok("Password has been reset successfully");
     }
 }

--- a/backend/src/main/java/com/tcs/dhv/domain/dto/ForgotPasswordDto.java
+++ b/backend/src/main/java/com/tcs/dhv/domain/dto/ForgotPasswordDto.java
@@ -1,0 +1,11 @@
+package com.tcs.dhv.domain.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ForgotPasswordDto(
+    @NotBlank
+    @Email
+    String email
+) {
+}

--- a/backend/src/main/java/com/tcs/dhv/domain/dto/ResetPasswordDto.java
+++ b/backend/src/main/java/com/tcs/dhv/domain/dto/ResetPasswordDto.java
@@ -1,0 +1,14 @@
+package com.tcs.dhv.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ResetPasswordDto(
+    @NotBlank
+    String token,
+
+    @NotBlank
+    @Size(min = 8, message = "Password must be at least {min} characters")
+    String newPassword
+) {
+}

--- a/backend/src/main/java/com/tcs/dhv/domain/dto/ResetPasswordDto.java
+++ b/backend/src/main/java/com/tcs/dhv/domain/dto/ResetPasswordDto.java
@@ -5,9 +5,6 @@ import jakarta.validation.constraints.Size;
 
 public record ResetPasswordDto(
     @NotBlank
-    String token,
-
-    @NotBlank
     @Size(min = 8, message = "Password must be at least {min} characters")
     String newPassword
 ) {

--- a/backend/src/main/java/com/tcs/dhv/domain/entity/PasswordResetToken.java
+++ b/backend/src/main/java/com/tcs/dhv/domain/entity/PasswordResetToken.java
@@ -34,4 +34,8 @@ public class PasswordResetToken {
 
     @Column(nullable = false)
     private Instant expiresAt;
+
+    public boolean isExpired() {
+        return expiresAt.isBefore(Instant.now());
+    }
 }

--- a/backend/src/main/java/com/tcs/dhv/domain/entity/PasswordResetToken.java
+++ b/backend/src/main/java/com/tcs/dhv/domain/entity/PasswordResetToken.java
@@ -9,13 +9,19 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.Instant;
 import java.util.UUID;
 
-@Data
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "password_reset_token")
 @Entity

--- a/backend/src/main/java/com/tcs/dhv/domain/entity/PasswordResetToken.java
+++ b/backend/src/main/java/com/tcs/dhv/domain/entity/PasswordResetToken.java
@@ -1,0 +1,37 @@
+package com.tcs.dhv.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@Table(name = "password_reset_token")
+@Entity
+public class PasswordResetToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false,  unique = true)
+    private String token;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private Instant expiresAt;
+}

--- a/backend/src/main/java/com/tcs/dhv/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/tcs/dhv/exception/GlobalExceptionHandler.java
@@ -1,9 +1,8 @@
 package com.tcs.dhv.exception;
 
 import com.tcs.dhv.domain.dto.ApiErrorResponse;
-
-import jakarta.validation.ConstraintViolationException;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -11,11 +10,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.Instant;
-
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -137,5 +136,16 @@ public class GlobalExceptionHandler {
                 .timestamp(Instant.now())
                 .build();
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(err);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        final var err = ApiErrorResponse.builder()
+            .status(HttpStatus.BAD_REQUEST.value())
+            .message("Invalid request body")
+            .timestamp(Instant.now())
+            .build();
+
+        return ResponseEntity.badRequest().body(err);
     }
 }

--- a/backend/src/main/java/com/tcs/dhv/repository/ResetTokenRepository.java
+++ b/backend/src/main/java/com/tcs/dhv/repository/ResetTokenRepository.java
@@ -3,8 +3,10 @@ package com.tcs.dhv.repository;
 import com.tcs.dhv.domain.entity.PasswordResetToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ResetTokenRepository extends JpaRepository<PasswordResetToken, UUID> {
     void deleteByUserId(UUID userId);
+    Optional<PasswordResetToken> findByToken(String token);
 }

--- a/backend/src/main/java/com/tcs/dhv/repository/ResetTokenRepository.java
+++ b/backend/src/main/java/com/tcs/dhv/repository/ResetTokenRepository.java
@@ -1,0 +1,10 @@
+package com.tcs.dhv.repository;
+
+import com.tcs.dhv.domain.entity.PasswordResetToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ResetTokenRepository extends JpaRepository<PasswordResetToken, UUID> {
+    void deleteByUserId(UUID userId);
+}

--- a/backend/src/main/java/com/tcs/dhv/service/EmailService.java
+++ b/backend/src/main/java/com/tcs/dhv/service/EmailService.java
@@ -75,8 +75,8 @@ public class EmailService {
     ) {
         final var token = otpService.generateAndStoreOtp(userId);
 
-        final var emailVerificationUrl = "%s/verified/%s/%s"
-            .formatted(clientUrl, userId, token);
+        final var emailVerificationUrl = "%s/api/auth/email/verify?uid=%s&t=%s"
+            .formatted(appBaseUrl, userId, token);
 
         final var context = new Context();
         context.setVariable("verifyLink", emailVerificationUrl);
@@ -212,8 +212,6 @@ public class EmailService {
         final String email,
         final String resetLink
     ) {
-        final var resetUrl = "%s/reset-password?token=%s".formatted(clientUrl, resetLink);
-
         final var emailText = """
             Hello,
             
@@ -226,7 +224,7 @@ public class EmailService {
             
             Regards,
             DHV Team
-            """.formatted(resetUrl);
+            """.formatted(resetLink);
 
         final var message = CreateMessage(
             "Password Reset Request",

--- a/backend/src/main/java/com/tcs/dhv/service/EmailService.java
+++ b/backend/src/main/java/com/tcs/dhv/service/EmailService.java
@@ -75,8 +75,8 @@ public class EmailService {
     ) {
         final var token = otpService.generateAndStoreOtp(userId);
 
-        final var emailVerificationUrl = "%s/api/auth/email/verify?uid=%s&t=%s"
-            .formatted(appBaseUrl, userId, token);
+        final var emailVerificationUrl = "%s/verified/%s/%s"
+            .formatted(clientUrl, userId, token);
 
         final var context = new Context();
         context.setVariable("verifyLink", emailVerificationUrl);

--- a/backend/src/main/java/com/tcs/dhv/service/EmailService.java
+++ b/backend/src/main/java/com/tcs/dhv/service/EmailService.java
@@ -208,4 +208,34 @@ public class EmailService {
         log.info("Address change notification email sent to {} for parcel {}", recipientEmail, trackingCode);
     }
 
+    public void sendPasswordResetEmail(
+        final String email,
+        final String resetLink
+    ) {
+        final var resetUrl = "%s/reset-password?token=%s".formatted(clientUrl, resetLink);
+
+        final var emailText = """
+            Hello,
+            
+            You requested a password reset for your DHV account. 
+            
+            Click the link below to reset your password:
+            %s
+            
+            if you didn't request this, please ignore this email.
+            
+            Regards,
+            DHV Team
+            """.formatted(resetUrl);
+
+        final var message = CreateMessage(
+            "Password Reset Request",
+            EmailConstants.EMAIL_SENDER,
+            email,
+            emailText
+        );
+
+        mailSender.send(message);
+        log.info("Password reset email sent to {}", email);
+    }
 }

--- a/backend/src/main/java/com/tcs/dhv/service/PasswordResetService.java
+++ b/backend/src/main/java/com/tcs/dhv/service/PasswordResetService.java
@@ -7,10 +7,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.security.SecureRandom;
 import java.time.Duration;
@@ -73,8 +71,7 @@ public class PasswordResetService {
     ) {
         final var resetToken = resetTokenRepository.findByToken(token)
             .filter(t -> !t.isExpired())
-            .orElseThrow(() -> new ResponseStatusException(
-                HttpStatus.BAD_REQUEST,
+            .orElseThrow(() -> new IllegalArgumentException(
                 "Token is invalid or expired"
             ));
 

--- a/backend/src/main/java/com/tcs/dhv/service/PasswordResetService.java
+++ b/backend/src/main/java/com/tcs/dhv/service/PasswordResetService.java
@@ -35,7 +35,7 @@ public class PasswordResetService {
     private static final Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
 
     private String generateSecureToken() {
-        byte[] randomBytes = new byte[32];
+        final var randomBytes = new byte[32];
         secureRandom.nextBytes(randomBytes);
         return encoder.encodeToString(randomBytes);
     }

--- a/backend/src/main/java/com/tcs/dhv/service/PasswordResetService.java
+++ b/backend/src/main/java/com/tcs/dhv/service/PasswordResetService.java
@@ -1,0 +1,64 @@
+package com.tcs.dhv.service;
+
+import com.tcs.dhv.domain.entity.PasswordResetToken;
+import com.tcs.dhv.repository.ResetTokenRepository;
+import com.tcs.dhv.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PasswordResetService {
+
+    private final ResetTokenRepository resetTokenRepository;
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+
+    @Value("${auth.reset-token-ttl}")
+    private Duration resetTokenTtl;
+
+    @Value("${dhv.client-url}")
+    private String clientUrl;
+
+    private static final SecureRandom secureRandom = new SecureRandom();
+    private static final Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+
+    private String generateSecureToken() {
+        byte[] randomBytes = new byte[32];
+        secureRandom.nextBytes(randomBytes);
+        return encoder.encodeToString(randomBytes);
+    }
+
+    @Transactional
+    public void sendResetToken(final String email) {
+        userRepository.findByEmail(email)
+            .ifPresent(user -> {
+                resetTokenRepository.deleteByUserId(user.getId());
+
+                final var token = generateSecureToken();
+                final var expiry = Instant.now().plus(resetTokenTtl);
+
+                final var resetToken = PasswordResetToken.builder()
+                    .token(token)
+                    .user(user)
+                    .expiresAt(expiry)
+                    .build();
+
+                resetTokenRepository.save(resetToken);
+
+                final var resetLink = "%s/reset-password?token=%s".formatted(clientUrl, token);
+                emailService.sendPasswordResetEmail(user.getEmail(), resetLink);
+
+                log.info("Password reset email sent to {}", user.getEmail());
+            });
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -55,6 +55,7 @@ jwt:
 
 auth:
   refresh-token-ttl: 24h
+  reset-token-ttl: 15m
 
 email-verification:
   required: true

--- a/backend/src/main/resources/db/migration/V10__add_password_reset_token.sql
+++ b/backend/src/main/resources/db/migration/V10__add_password_reset_token.sql
@@ -1,0 +1,9 @@
+CREATE TABLE password_reset_token (
+    id         UUID PRIMARY KEY,
+    token      VARCHAR(255) NOT NULL UNIQUE,
+    user_id    UUID NOT NULL,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    CONSTRAINT fk_password_reset_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+CREATE INDEX idx_password_reset_token_token ON password_reset_token (token);
+CREATE INDEX idx_password_reset_token_user_id ON password_reset_token (user_id);


### PR DESCRIPTION
## Still in progress!

- Introduced `ForgotPasswordDto` to handle password reset requests by email
- Added `ResetPasswordDto` to receive the reset token and new password from the client
- Added `isExpired()` method to `PasswordResetToken` entity for token expiration checks
- Implemented `PasswordResetService` to:
  - Generate and store secure reset tokens
  - Validate token expiration and reset user passwords
  - Delete used tokens after successful reset
- Updated `EmailService` to send password reset emails with frontend reset link
- Added controller endpoints:
  - `POST /api/auth/password/forgot` to request reset link
  - `POST /api/auth/password/reset` to apply the new password
- Integrated DTO validation and global exception handling for invalid requests
- Reset link format updated to point to frontend route with token as query param


