### PR TITLE
fix(user): prevented deletion of users with undelivered parcels

### DIFF
--- a/backend/src/main/java/com/tcs/dhv/repository/ParcelRepository.java
+++ b/backend/src/main/java/com/tcs/dhv/repository/ParcelRepository.java
@@ -1,11 +1,13 @@
 package com.tcs.dhv.repository;
 
 import com.tcs.dhv.domain.entity.Parcel;
+import com.tcs.dhv.domain.enums.ParcelStatus;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public interface ParcelRepository extends JpaRepository<Parcel, UUID> {
@@ -18,4 +20,7 @@ public interface ParcelRepository extends JpaRepository<Parcel, UUID> {
 
     @EntityGraph(attributePaths = {"sender", "sender.address", "recipient", "recipient.address"})
     Optional<Parcel> findByTrackingCode(String trackingCode);
+
+    boolean existsBySenderIdAndCurrentStatusIn(UUID senderId, Set<ParcelStatus> status);
+    boolean existsByRecipientIdAndCurrentStatusIn(UUID recipientId, Set<ParcelStatus> status);
 }

--- a/backend/src/main/java/com/tcs/dhv/repository/ParcelRepository.java
+++ b/backend/src/main/java/com/tcs/dhv/repository/ParcelRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public interface ParcelRepository extends JpaRepository<Parcel, UUID> {
@@ -20,6 +21,6 @@ public interface ParcelRepository extends JpaRepository<Parcel, UUID> {
     @EntityGraph(attributePaths = {"sender", "sender.address", "recipient", "recipient.address"})
     Optional<Parcel> findByTrackingCode(String trackingCode);
 
-    boolean existsBySenderIdAndCurrentStatus(UUID senderId, ParcelStatus status);
-    boolean existsByRecipientIdAndCurrentStatus(UUID recipientId, ParcelStatus status);
+    boolean existsBySenderIdAndCurrentStatusIn(UUID senderId, Set<ParcelStatus> status);
+    boolean existsByRecipientIdAndCurrentStatusIn(UUID recipientId, Set<ParcelStatus> status);
 }

--- a/backend/src/main/java/com/tcs/dhv/repository/ParcelRepository.java
+++ b/backend/src/main/java/com/tcs/dhv/repository/ParcelRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 public interface ParcelRepository extends JpaRepository<Parcel, UUID> {
@@ -21,6 +20,6 @@ public interface ParcelRepository extends JpaRepository<Parcel, UUID> {
     @EntityGraph(attributePaths = {"sender", "sender.address", "recipient", "recipient.address"})
     Optional<Parcel> findByTrackingCode(String trackingCode);
 
-    boolean existsBySenderIdAndCurrentStatusIn(UUID senderId, Set<ParcelStatus> status);
-    boolean existsByRecipientIdAndCurrentStatusIn(UUID recipientId, Set<ParcelStatus> status);
+    boolean existsBySenderIdAndCurrentStatus(UUID senderId, ParcelStatus status);
+    boolean existsByRecipientIdAndCurrentStatus(UUID recipientId, ParcelStatus status);
 }

--- a/backend/src/main/java/com/tcs/dhv/service/UserService.java
+++ b/backend/src/main/java/com/tcs/dhv/service/UserService.java
@@ -109,8 +109,14 @@ public class UserService {
             ParcelStatus.RETURNED_TO_SENDER
         );
 
-        final boolean hasUndeliveredSentParcels = parcelRepository.existsBySenderIdAndCurrentStatusIn(userId, undeliveredStatus);
-        final boolean hasUndeliveredReceivedParcels = parcelRepository.existsByRecipientIdAndCurrentStatusIn(userId, undeliveredStatus);
+        final boolean hasUndeliveredSentParcels = parcelRepository.existsBySenderIdAndCurrentStatusIn(
+            userId,
+            undeliveredStatus
+        );
+        final boolean hasUndeliveredReceivedParcels = parcelRepository.existsByRecipientIdAndCurrentStatusIn(
+            userId,
+            undeliveredStatus
+        );
 
         if (hasUndeliveredSentParcels || hasUndeliveredReceivedParcels) {
             log.warn("Attempted to delete user with ID: {} who has undelivered parcels", userId);

--- a/backend/src/main/java/com/tcs/dhv/service/UserService.java
+++ b/backend/src/main/java/com/tcs/dhv/service/UserService.java
@@ -18,8 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
-import java.util.EnumSet;
-import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
@@ -100,22 +98,13 @@ public class UserService {
         final var user = userRepository.findById(userId)
             .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + userId));
 
-        final Set<ParcelStatus> undeliveredStatus = EnumSet.of(
-            ParcelStatus.CREATED,
-            ParcelStatus.PICKED_UP,
-            ParcelStatus.IN_TRANSIT,
-            ParcelStatus.OUT_FOR_DELIVERY,
-            ParcelStatus.DELIVERY_ATTEMPTED,
-            ParcelStatus.RETURNED_TO_SENDER
-        );
-
-        final boolean hasUndeliveredSentParcels = parcelRepository.existsBySenderIdAndCurrentStatusIn(
+        final var hasUndeliveredSentParcels = parcelRepository.existsBySenderIdAndCurrentStatus(
             userId,
-            undeliveredStatus
+            ParcelStatus.DELIVERED
         );
-        final boolean hasUndeliveredReceivedParcels = parcelRepository.existsByRecipientIdAndCurrentStatusIn(
+        final var hasUndeliveredReceivedParcels = parcelRepository.existsByRecipientIdAndCurrentStatus(
             userId,
-            undeliveredStatus
+            ParcelStatus.DELIVERED
         );
 
         if (hasUndeliveredSentParcels || hasUndeliveredReceivedParcels) {

--- a/backend/src/main/java/com/tcs/dhv/service/UserService.java
+++ b/backend/src/main/java/com/tcs/dhv/service/UserService.java
@@ -3,17 +3,23 @@ package com.tcs.dhv.service;
 import com.tcs.dhv.domain.dto.UserProfileDto;
 import com.tcs.dhv.domain.entity.Address;
 import com.tcs.dhv.domain.entity.User;
+import com.tcs.dhv.domain.enums.ParcelStatus;
 import com.tcs.dhv.repository.AddressRepository;
+import com.tcs.dhv.repository.ParcelRepository;
 import com.tcs.dhv.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ValidationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
@@ -24,6 +30,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final AddressRepository addressRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ParcelRepository parcelRepository;
 
     public UserProfileDto getUserProfile(final String userIdentifier) {
         final var userId = UUID.fromString(userIdentifier);
@@ -89,8 +96,31 @@ public class UserService {
 
     @Transactional
     public void deleteUserProfile(final UUID userId) {
+        log.info("Request to delete user profile with ID: {}", userId);
         final var user = userRepository.findById(userId)
             .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + userId));
+
+        final Set<ParcelStatus> undeliveredStatus = EnumSet.of(
+            ParcelStatus.CREATED,
+            ParcelStatus.PICKED_UP,
+            ParcelStatus.IN_TRANSIT,
+            ParcelStatus.OUT_FOR_DELIVERY,
+            ParcelStatus.DELIVERY_ATTEMPTED,
+            ParcelStatus.RETURNED_TO_SENDER
+        );
+
+        final boolean hasUndeliveredSentParcels = parcelRepository.existsBySenderIdAndCurrentStatusIn(userId, undeliveredStatus);
+        final boolean hasUndeliveredReceivedParcels = parcelRepository.existsByRecipientIdAndCurrentStatusIn(userId, undeliveredStatus);
+
+        if (hasUndeliveredSentParcels || hasUndeliveredReceivedParcels) {
+            log.warn("Attempted to delete user with ID: {} who has undelivered parcels", userId);
+            throw new ResponseStatusException(
+                HttpStatus.CONFLICT,
+                "Cannot delete user profile with undelivered parcels"
+            );
+        }
+
+        log.info("User profile deleted for ID: {}", userId);
         userRepository.delete(user);
     }
 


### PR DESCRIPTION
Reverted the user deletion logic to enforce the original restriction: users cannot be deleted if they have any undelivered parcels.

Changes:
- Reintroduced the check for undelivered parcel statuses using an `EnumSet` (`CREATED`, `PICKED_UP`, `IN_TRANSIT`, `OUT_FOR_DELIVERY`, `DELIVERY_ATTEMPTED`, `RETURNED_TO_SENDER`)
- Reverted repository method signatures to accept a `Set<ParcelStatus>` instead of a single status
- Re-added logic to check both sent and received parcels for undelivered statuses
- Extracted user lookup into a reusable method `getUserById(userId)` for consistency and clarity